### PR TITLE
fix: remove api loadRemoteLanguageExtensions

### DIFF
--- a/zgsm/src/common/services.ts
+++ b/zgsm/src/common/services.ts
@@ -12,7 +12,7 @@ import { getExtensionsLatestVersion } from "./api"
 import { EXTENSION_ID, configCompletion, configCodeLens } from "./constant"
 import { envSetting } from "./env"
 import { Logger } from "./log-util"
-import { LangSetting, LangSwitch, LangDisables, getLanguageByFilePath, loadRemoteLanguageExtensions } from "./lang-util"
+import { LangSetting, LangSwitch, LangDisables, getLanguageByFilePath } from "./lang-util"
 import { DateFormat, formatTime, formatTimeDifference } from "./util"
 import { t } from "../../../src/i18n"
 import { zgsmProviderKey } from "../../../src/shared/api"
@@ -23,12 +23,12 @@ import { generateZgsmAuthUrl } from "../../../src/shared/zgsmAuthUrl"
  */
 export function setupExtensionUpdater(context: vscode.ExtensionContext) {
 	setTimeout(() => {
-		loadRemoteLanguageExtensions()
+		// loadRemoteLanguageExtensions()
 		updateExtensions(context)
 	}, 3000)
 	setInterval(
 		() => {
-			loadRemoteLanguageExtensions() // Load language extension data
+			// loadRemoteLanguageExtensions() // Load language extension data
 			updateExtensions(context) // Check for extension updates
 		},
 		1000 * 60 * 60,


### PR DESCRIPTION
the API `loadRemoteLanguageExtensions` calls have been temporarily disabled due to a backend issue.
![image](https://github.com/user-attachments/assets/5f63964d-f0a3-4675-bdfb-3df6db396cce)

