### PR TITLE
feat: support custom auth url

### DIFF
--- a/src/exports/roo-code.d.ts
+++ b/src/exports/roo-code.d.ts
@@ -26,6 +26,10 @@ type ProviderSettings = {
 	zgsmBaseUrl?: string | undefined
 	zgsmApiKey?: string | undefined
 	zgsmModelId?: string | undefined
+	customZgsmLoginUrl?: string | undefined
+	customZgsmLogoutUrl?: string | undefined
+	customZgsmTokenUrl?: string | undefined
+	customZgsmRedirectUri?: string | undefined
 	zgsmDefaultBaseUrl?: string | undefined
 	zgsmDefaultModelId?: string | undefined
 	zgsmSite?: string | undefined

--- a/src/exports/types.ts
+++ b/src/exports/types.ts
@@ -27,6 +27,10 @@ type ProviderSettings = {
 	zgsmBaseUrl?: string | undefined
 	zgsmApiKey?: string | undefined
 	zgsmModelId?: string | undefined
+	customZgsmLoginUrl?: string | undefined
+	customZgsmLogoutUrl?: string | undefined
+	customZgsmTokenUrl?: string | undefined
+	customZgsmRedirectUri?: string | undefined
 	zgsmDefaultBaseUrl?: string | undefined
 	zgsmDefaultModelId?: string | undefined
 	zgsmSite?: string | undefined

--- a/src/schemas/index.ts
+++ b/src/schemas/index.ts
@@ -311,6 +311,10 @@ export const providerSettingsSchema = z.object({
 	zgsmBaseUrl: z.string().optional(),
 	zgsmApiKey: z.string().optional(),
 	zgsmModelId: z.string().optional(),
+	customZgsmLoginUrl: z.string().optional(),
+	customZgsmLogoutUrl: z.string().optional(),
+	customZgsmTokenUrl: z.string().optional(),
+	customZgsmRedirectUri: z.string().optional(),
 
 	zgsmDefaultBaseUrl: z.string().optional(),
 	zgsmDefaultModelId: z.string().optional(),
@@ -425,6 +429,10 @@ const providerSettingsRecord: ProviderSettingsRecord = {
 	zgsmBaseUrl: undefined,
 	zgsmApiKey: undefined,
 	zgsmModelId: undefined,
+	customZgsmLoginUrl: undefined,
+	customZgsmLogoutUrl: undefined,
+	customZgsmTokenUrl: undefined,
+	customZgsmRedirectUri: undefined,
 
 	zgsmSite: undefined,
 	zgsmDefaultBaseUrl: undefined,

--- a/src/shared/zgsmAuthUrl.ts
+++ b/src/shared/zgsmAuthUrl.ts
@@ -7,13 +7,20 @@ export function getZgsmAuthUrl(stateId: string, apiConfiguration?: ApiConfigurat
 	const params = [
 		["response_type", "code"],
 		["client_id", `${apiConfiguration?.zgsmClientId}`],
-		["redirect_uri", `${baseUrl}${apiConfiguration?.zgsmRedirectUri}`],
+		[
+			"redirect_uri",
+			apiConfiguration?.customZgsmRedirectUri
+				? apiConfiguration?.customZgsmRedirectUri
+				: `${baseUrl}${apiConfiguration?.zgsmRedirectUri}`,
+		],
 		["state", stateId],
 		["scope", scopes.join(" ")],
 	]
 	const searchParams = new URLSearchParams(params)
 
-	return `${baseUrl}${apiConfiguration?.zgsmLoginUrl}?${searchParams.toString()}`
+	return apiConfiguration?.customZgsmLoginUrl
+		? `${apiConfiguration.customZgsmLoginUrl}?${searchParams.toString()}`
+		: `${baseUrl}${apiConfiguration?.zgsmLoginUrl}?${searchParams.toString()}`
 }
 
 /**

--- a/src/zgsmAuth/zgsmAuthHandler.ts
+++ b/src/zgsmAuth/zgsmAuthHandler.ts
@@ -124,7 +124,14 @@ export async function handleZgsmLogin(
  */
 export async function getZgsmAccessToken(code: string, apiConfiguration?: ApiConfiguration) {
 	try {
-		const { redirectUri, tokenUrl } = defaultZgsmAuthConfig.getAuthUrls(apiConfiguration?.zgsmBaseUrl)
+		const baseUrl =
+			apiConfiguration?.zgsmBaseUrl || apiConfiguration?.zgsmDefaultBaseUrl || defaultZgsmAuthConfig.baseUrl
+		const redirectUri =
+			apiConfiguration?.customZgsmRedirectUri ||
+			`${baseUrl}${apiConfiguration?.zgsmRedirectUri || defaultZgsmAuthConfig.redirectUri}`
+		const tokenUrl =
+			apiConfiguration?.customZgsmTokenUrl ||
+			`${baseUrl}${apiConfiguration?.zgsmTokenUrl || defaultZgsmAuthConfig.tokenUrl}`
 
 		// Prefer configuration in apiConfiguration, if not exist, use environment settings
 		const clientId = apiConfiguration?.zgsmClientId || defaultZgsmAuthConfig.clientId

--- a/webview-ui/src/i18n/locales/en/settings.json
+++ b/webview-ui/src/i18n/locales/en/settings.json
@@ -445,5 +445,8 @@
 	"labels": {
 		"customArn": "Custom ARN",
 		"useCustomArn": "Use custom ARN..."
+	},
+	"error": {
+		"failed_to_fetch_auth_url_config": "Failed to fetch authentication URL configuration: "
 	}
 }

--- a/webview-ui/src/i18n/locales/zh-CN/settings.json
+++ b/webview-ui/src/i18n/locales/zh-CN/settings.json
@@ -446,5 +446,8 @@
 	"labels": {
 		"customArn": "自定义 ARN",
 		"useCustomArn": "使用自定义 ARN..."
+	},
+	"error": {
+		"failed_to_fetch_auth_url_config": "无法获取身份验证URL配置："
 	}
 }

--- a/webview-ui/src/i18n/locales/zh-TW/settings.json
+++ b/webview-ui/src/i18n/locales/zh-TW/settings.json
@@ -445,5 +445,8 @@
 	"labels": {
 		"customArn": "自訂 ARN",
 		"useCustomArn": "使用自訂 ARN..."
+	},
+	"error": {
+		"failed_to_fetch_auth_url_config": "無法取得身份驗證URL設定："
 	}
 }

--- a/webview-ui/src/utils/zgsmAuth.ts
+++ b/webview-ui/src/utils/zgsmAuth.ts
@@ -1,6 +1,27 @@
 import { vscode } from "./vscode"
 import { ApiConfiguration } from "../../../src/shared/api"
 import { generateZgsmAuthUrl } from "../../../src/shared/zgsmAuthUrl"
+import i18next from "i18next"
+
+/**
+ * Fetch ZGSM configuration from API
+ * @param baseUrl Base URL for the API
+ */
+export async function fetchZgsmAuthConfiguration(baseUrl: string): Promise<any> {
+	const response = await fetch(`${baseUrl}/api/configuration?belong_type=authenticate&attribute_key=custom_url`)
+	if (!response.ok) {
+		throw new Error(i18next.t("settings:error.failed_to_fetch_auth_url_config") + response.statusText)
+	}
+	const responseData = await response.json()
+	if (!responseData.success) {
+		throw new Error(i18next.t("settings:error.failed_to_fetch_auth_url_config") + responseData.message)
+	}
+
+	if (!responseData.data || responseData.data.length === 0) {
+		return {}
+	}
+	return responseData.data[0].attribute_value || {}
+}
 
 /**
  * Initiate ZGSM login authentication process


### PR DESCRIPTION
Support calling the backend '/api/configuration?belong_type=authenticate&attribute_key=custom_url' interface to obtain user-defined auth URL configuration