### PR TITLE
fix: add truncateContent function to limit file content size

### DIFF
--- a/src/core/tools/readFileTool.ts
+++ b/src/core/tools/readFileTool.ts
@@ -12,6 +12,7 @@ import { readLines } from "../../integrations/misc/read-lines"
 import { extractTextFromFile, addLineNumbers } from "../../integrations/misc/extract-text"
 import { parseSourceCodeDefinitionsForFile } from "../../services/tree-sitter"
 import { isBinaryFile } from "isbinaryfile"
+import { truncateContent } from "../../../zgsm/src/core/tools/readFileTool"
 
 export async function readFileTool(
 	cline: Cline,
@@ -165,6 +166,9 @@ export async function readFileTool(
 			} else {
 				// Read entire file
 				content = await extractTextFromFile(absolutePath)
+
+				// Truncate content based on line count or character count
+				content = truncateContent(content, maxReadFileLine);
 			}
 
 			// Create variables to store XML components

--- a/zgsm/src/core/tools/__tests__/readFileTool.test.ts
+++ b/zgsm/src/core/tools/__tests__/readFileTool.test.ts
@@ -1,0 +1,77 @@
+// npx jest zgsm/src/core/tools/__tests__/readFileTool.test.ts
+
+import { truncateContent } from '../readFileTool';
+
+describe('truncateContent', () => {
+  const maxLines = 5; // Use smaller line limit for testing
+
+  // Tests for default limits
+  describe('default limits', () => {
+    it('should return original content when under both limits', () => {
+      const content = 'line1\nline2\nline3';
+      const result = truncateContent(content);
+      expect(result).toBe(content);
+    });
+
+    it('should truncate by lines when exceeding line limit', () => {
+      const lines = Array.from({length: 600}, (_, i) => `line${i+1}`);
+      const content = lines.join('\n');
+      const result = truncateContent(content);
+      
+      const resultLines = result.split('\n');
+      expect(resultLines.length).toBe(501);
+      expect(resultLines[0]).toBe('line1');
+      expect(resultLines[499]).toBe('line500');
+      expect(result.endsWith('\n')).toBeTruthy();
+    });
+
+    it('should truncate by chars when exceeding character limit', () => {
+      const longContent = 'a'.repeat(25000);
+      const result = truncateContent(longContent);
+      
+      expect(result.length).toBe(20000);
+      expect(result).toBe(longContent.substring(0, 20000));
+    });
+  });
+
+  // Tests for custom line limits
+  describe('custom line limit', () => {
+    it('should respect custom line limit', () => {
+      const lines = Array.from({length: 10}, (_, i) => `line${i+1}`);
+      const content = lines.join('\n');
+      const result = truncateContent(content, maxLines);
+      
+      const resultLines = result.split('\n');
+      expect(resultLines.length).toBe(maxLines+1);
+      expect(resultLines[0]).toBe('line1');
+      expect(resultLines[maxLines-1]).toBe(`line${maxLines}`);
+    });
+
+    it('should use default when custom line limit is 0 or negative', () => {
+      const lines = Array.from({length: 600}, (_, i) => `line${i+1}`);
+      const content = lines.join('\n');
+      
+      const result1 = truncateContent(content, 0);
+      expect(result1.split('\n').length).toBe(501);
+      
+      const result2 = truncateContent(content, -10);
+      expect(result2.split('\n').length).toBe(501);
+    });
+  });
+
+  // Tests for edge cases
+  describe('edge cases', () => {
+    it('should handle empty string', () => {
+      expect(truncateContent('')).toBe('');
+    });
+
+    it('should handle content exactly at limits', () => {
+      const exactLines = Array.from({length: 500}, (_, i) => `line${i+1}`);
+      const exactLineContent = exactLines.join('\n');
+      expect(truncateContent(exactLineContent).split('\n').length).toBe(500);
+      
+      const exactCharsContent = 'a'.repeat(20000);
+      expect(truncateContent(exactCharsContent).length).toBe(20000);
+    });
+  });
+});

--- a/zgsm/src/core/tools/readFileTool.ts
+++ b/zgsm/src/core/tools/readFileTool.ts
@@ -1,0 +1,31 @@
+
+/**
+ * Truncates file content to prevent performance issues from large files
+ * @param content - The original file content to be processed
+ * @param maxReadFileLine - Optional maximum line limit (if <= 0 uses default 500)
+ * @returns The processed content (potentially truncated)
+ */
+export function truncateContent(content: string, maxReadFileLine: number = 500): string {
+    // Maximum number of lines allowed
+    const MAX_LINES = maxReadFileLine > 0 ? maxReadFileLine : 500;
+    // Maximum number of characters allowed
+    const MAX_CHARS = 20000;
+
+    // First check if the content exceeds the line limit
+    // Split content into array by newlines to count lines
+    const lines = content.split('\n');
+    if (lines.length > MAX_LINES) {
+        // If exceeds line limit, keep only first 500 lines
+        // Use join('\n') to recombine content and add newline at end to maintain format
+        return lines.slice(0, MAX_LINES).join('\n') + '\n';
+    }
+
+    // Then check if total character count exceeds limit
+    if (content.length > MAX_CHARS) {
+        // If exceeds character limit, keep only first 20000 characters
+        return content.substring(0, MAX_CHARS);
+    }
+
+    // If content doesn't exceed any limits, return original
+    return content;
+}


### PR DESCRIPTION
Apply line number and character count limitations when reading entire files in readFileTool