### PR TITLE
chore: add zgsm/src to Jest roots for improved test coverage

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -41,7 +41,7 @@ module.exports = {
 	transformIgnorePatterns: [
 		"node_modules/(?!(@modelcontextprotocol|delay|p-wait-for|globby|serialize-error|strip-ansi|default-shell|os-name|strip-bom)/)",
 	],
-	roots: ["<rootDir>/src", "<rootDir>/webview-ui/src"],
+	roots: ["<rootDir>/src", "<rootDir>/webview-ui/src", "<rootDir>/zgsm/src"],
 	modulePathIgnorePatterns: [".vscode-test"],
 	reporters: [["jest-simple-dot-reporter", {}]],
 	setupFiles: ["<rootDir>/src/__mocks__/jest.setup.ts"],


### PR DESCRIPTION
Modify jest.config.js configuration to support test files under zgsm/src