### PR TITLE
fix: Fix Github Actions to automatically publish to release

### DIFF
--- a/.github/workflows/marketplace-publish.yml
+++ b/.github/workflows/marketplace-publish.yml
@@ -38,7 +38,7 @@ jobs:
         run: |
           current_package_version=$(node -p "require('./package.json').version")
           npm run vsix
-          package=$(unzip -l bin/roo-cline-${current_package_version}.vsix)
+          package=$(unzip -l bin/zgsm-${current_package_version}.vsix)
           echo "$package"
           echo "$package" | grep -q "dist/extension.js" || exit 1
           echo "$package" | grep -q "extension/webview-ui/build/assets/index.js" || exit 1
@@ -50,14 +50,14 @@ jobs:
           git tag -a "v${current_package_version}" -m "Release v${current_package_version}"
           git push origin "v${current_package_version}"
           echo "Successfully created and pushed git tag v${current_package_version}"
-      - name: Publish Extension
-        env:
-          VSCE_PAT: ${{ secrets.VSCE_PAT }}
-          OVSX_PAT: ${{ secrets.OVSX_PAT }}
-        run: |
-          current_package_version=$(node -p "require('./package.json').version")
-          npm run publish:marketplace
-          echo "Successfully published version $current_package_version to VS Code Marketplace"
+      # - name: Publish Extension
+      #   env:
+      #     VSCE_PAT: ${{ secrets.VSCE_PAT }}
+      #     OVSX_PAT: ${{ secrets.OVSX_PAT }}
+      #   run: |
+      #     current_package_version=$(node -p "require('./package.json').version")
+      #     npm run publish:marketplace
+      #     echo "Successfully published version $current_package_version to VS Code Marketplace"
       - name: Create GitHub Release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -81,5 +81,5 @@ jobs:
             --title "Release v${current_package_version}" \
             --notes "$changelog_content" \
             --target ${{ env.GIT_REF }} \
-            bin/roo-cline-${current_package_version}.vsix
+            bin/zgsm-${current_package_version}.vsix
           echo "Successfully created GitHub Release v${current_package_version}"


### PR DESCRIPTION


Updated the "Publish Extension" GitHub Actions workflow to correctly package and publish releases to GitHub Release. This change ensures that the release process completes successfully and uploads the appropriate versioned assets.

## Context

Now, as long as the title of the PR merged into the main branch contains "Changeset version bump", the version will be automatically published to github release.

## Implementation

<!--

Some description of HOW you achieved it. Perhaps give a high level description of the program flow. Did you need to refactor something? What tradeoffs did you take? Are there things in here which you’d particularly like people to pay close attention to?

-->

## Screenshots

| before | after |
| ------ | ----- |
|        |       |

## How to Test

<!--

A straightforward scenario of how to test your changes will help reviewers that are not familiar with the part of the code that you are changing but want to see it in action. This section can include a description or step-by-step instructions of how to get to the state of v2 that your change affects.

A "How To Test" section can look something like this:

- Sign in with a user with tracks
- Activate `show_awesome_cat_gifs` feature (add `?feature.show_awesome_cat_gifs=1` to your URL)
- You should see a GIF with cats dancing

-->

## Get in Touch

<!-- We'd love to have a way to chat with you about your changes if necessary. If you're in the [Roo Code Discord](https://discord.gg/roocode), please share your handle here. -->
