### PR TITLE
feat: merge roocode

### DIFF
--- a/src/integrations/editor/DiffViewProvider.ts
+++ b/src/integrations/editor/DiffViewProvider.ts
@@ -122,7 +122,7 @@ export class DiffViewProvider {
 		const endLine = accumulatedLines.length
 		// Replace all content up to the current line with accumulated lines.
 		const edit = new vscode.WorkspaceEdit()
-		const rangeToReplace = new vscode.Range(0, 0, endLine + 1, 0)
+		const rangeToReplace = new vscode.Range(0, 0, endLine, 0)
 		const contentToReplace = accumulatedLines.slice(0, endLine + 1).join("\n") + "\n"
 		edit.replace(document.uri, rangeToReplace, this.stripAllBOMs(contentToReplace))
 		await vscode.workspace.applyEdit(edit)
@@ -130,7 +130,10 @@ export class DiffViewProvider {
 		this.activeLineController.setActiveLine(endLine)
 		this.fadedOverlayController.updateOverlayAfterLine(endLine, document.lineCount)
 		// Scroll to the current line.
-		this.scrollEditorToLine(endLine)
+		const ranges = this.activeDiffEditor?.visibleRanges
+		if (ranges && ranges.length > 0 && ranges[0].start.line < endLine && ranges[0].end.line > endLine) {
+			this.scrollEditorToLine(endLine)
+		}
 
 		// Update the streamedLines with the new accumulated content.
 		this.streamedLines = accumulatedLines
@@ -361,7 +364,7 @@ export class DiffViewProvider {
 					query: Buffer.from(this.originalContent ?? "").toString("base64"),
 				}),
 				uri,
-				`${fileName}: ${fileExists ? "Original ↔ Roo's Changes" : "New File"} (Editable)`,
+				`${fileName}: ${fileExists ? "Original ↔ Shenma's Changes" : "New File"} (Editable)`,
 				{ preserveFocus: true },
 			)
 

--- a/src/shared/combineApiRequests.ts
+++ b/src/shared/combineApiRequests.ts
@@ -43,9 +43,7 @@ export function combineApiRequests(messages: ClineMessage[]): ClineMessage[] {
 	const result: ClineMessage[] = []
 	const startedIndices: number[] = []
 
-	for (let i = 0; i < messages.length; i++) {
-		const message = messages[i]
-
+	for (const message of messages) {
 		if (message.type !== "say" || (message.say !== "api_req_started" && message.say !== "api_req_finished")) {
 			result.push(message)
 			continue

--- a/src/utils/xml-matcher.ts
+++ b/src/utils/xml-matcher.ts
@@ -42,8 +42,7 @@ export class XmlMatcher<Result = XmlMatcherResult> {
 	}
 
 	private _update(chunk: string) {
-		for (let i = 0; i < chunk.length; i++) {
-			const char = chunk[i]
+		for (const char of chunk) {
 			this.cached.push(char)
 			this.pointer++
 


### PR DESCRIPTION
* Rename cline_docs -> docs (#3587)

* Update contributors list (#3299)



* fix(deps): update dependency posthog-js to v1.242.1 (#3602)



* Use a shadcn dialog for the announcement (#3604)

* feat: add buildDocLink utility and 21 Internal Links to Docs (#3418)



* Add build vsix Workflow (#3600)

* build: enable source maps for improved debugging (#3596)



* v3.16.7 (#3614)

* [Condense] Condense messages with an LLM rather than truncating (#3582)



* Fix type generation (#3619)

* Update contributors list (#3612)



* v3.17.0 (#3622)

* Changeset version bump (#3556)




* fix: correct Changelog link in localized README files (#3629)

The Changelog link in `locales/ja/README.md` and other localized READMEswas pointing to a broken relative path, resulting in 404s.This commit updates the link to use a correct relative path (`../../CHANGELOG.md`)so that it works across all locales.

* Fix incorrect reserved tokens calculation on OpenRouter (#3626)

fix: improve token reservation logic in calculateTokenDistribution

* Fix command display in the approval required case (#3636)

* Changeset version bump (#3637)





* Fix how custom instructions are loaded into the API request (#3638)p

* Lock the versions of vsce and ovsx (#3643)

* Revert "Switch to the new Roo message parser" (#3649)

* Changeset version bump (#3645)




* Import settings bug fix / improvements (#3657)

* Export ProviderName type to Roo-Code-Types (#3675)

* Log Cleanup to Remove Cline (#3704)

* Rename Errors & Fix Spelling Mistake

* Update src/core/task/Task.ts



---------




* #3679 - Fixes packaging to include correct tiktoken.wasm (lite) (#3697)

- also, additions to .gitignore and .vscodeignore to prevent the IntelliJ .idea and .qodo folders from being included for git and packaging.

* Adds refresh models button for Unbound provider (#3663)

* Adds refresh models button for Unbound provider

* Adds changeset

* Optimizes code to prevent memory leak, add error messages

* Adds unbound messages to all supported languages

---------



* Add Qwen3 model series to the Chutes provider (#3710)

* Add Qwen3 model series to the Chutes provider

New models for the Chutes provider:

- Qwen/Qwen3-235B-A22B
- Qwen/Qwen3-32B
- Qwen/Qwen3-30B-A3B
- Qwen/Qwen3-14B
- Qwen/Qwen3-8B

* add changeset

* fix(webview): Fix links to filename:0 (#3727)

* fix(webview): Fix links to filename:0

* Add changeset

* LM studio reasoning support (thinking block) (#3719)

lmstudio reasoning support (thinking block)

Similar to ollama implementation in #1080

* feat(evals): add UI and backend support for importing and injecting f… (#3606)

* [Condense Context] Track metrics around context condensing and show in UI

* Add UI component

* account for system prompt when estimating new context size

* add header

* bug fix

* nit

* nit

* refactor

* fix

* add unit tests for condense

* update sliding-window tests

* add getApiMetrics.test.ts

* fix failing tests

* use chat.json

* add translations

* add tests for ContextCondenseRow

* add changeset

* camelCase

* use Markdown for summary

* use tailwind

* non default export

* rm test :/

* Make prompt input textareas resizable (#3691) (#3739)

* feat: move play audio to webview to ensure cross-platform (#3659)



* refactor:  import multiple times (#3745)

* Add YAML support for .roomode files alongside JSON processing (#3711)

* ✨ feat(settings): Add allowedMaxRequests feature inspired by Cline (#3631)

* feat(settings): Introduce the "auto-approve request count" feature from Cline

This is the first minor UI feature I've added, so please let me know if I'm missing anything! (translations, organization, etc!)

Please see commits for details

introduce allowedMaxRequests to globalSettingsSchema update ExtensionState and its context with allowedMaxRequests implement UI for setting max requests in AutoApproveMenu component prompt user when auto-approval limit is reached with i18n support increment consecutiveAutoApprovedRequestsCount and reset upon user approval add translations for auto-approved request limit reached prompt in multiple languages add new UI for "auto_approval_max_req_reached" in ChatRowContent display prompt with title, description, and button for user action

🔧 chore(gitignore): add .idea to .gitignore to exclude IDE-specific files
- remove .idea/workspace.xml to clean up repository

* 🔧 chore(gitignore): add IDE configuration files to ignore list

- add .idea directory to ignore JetBrains IDE configurations

* 🌐 i18n(chat): add translation keys for api request limit

- introduce translation keys for "title" and "unlimited" in multiple languages
- update description for api request limit in various languages

* 🌐 i18n(chat): migrate auto-approved request limit translations

- move translations from common.json to chat.json across locales
- update component to use Trans for dynamic text rendering

* Update the UI for setting max requests

* Hide the auto-approve limit warning once clicked

---------



* Move error message for settings import failure into the correct position (#3752)




* feat: use template variables for version numbers in announcement strings (#3755)

* Auto-reload core changes in dev mode (#3284)



* Moved repo to new org (#3756)

* Use yaml as default custom modes format (#3749)

* [Condense] Add a button to condense the task context (#3623)

* [Condense] Add a button to condense the task context

* wip

* wip

* wip

* bring back delete size

* account for the system prompt in the context

* update tests to use systemPrompt

* add type

* translations

* nit

* update tests

* filter to the current task

* nit

* refactor

* nit

* non interactive option

* simplify chat summary UI

* changeset

* nit

* fix check-types

* throw

* [Condense] Fix double counting last message when condensing (#3763)

* Get package publisher and name from package.json + command type safety (#3766)

* Lm studio and ollama usage fix (#3707)

* integration

* Fix

* [Condense] Change condense icon (#3768)

* [Condense] Change condense icon

* change to fold

* feat: add gemini-2.5-flash-preview-05-20 models (#3769)

* Add Gemini Flash 2.5 05-20 variants for the Vertex provider (#3758)

* feat(api): add gemini-2.5-flash-preview-05-20 model configuration

* feat(tests): update apiModelId to gemini-2.5-flash-preview-05-20 in ProviderSettingsManager tests in case the old version is deprecated

* chore: add changeset

* feat(api): update vertexModels to add gemini-2.5-flash-preview-05-20 variants

* chore: update changeset

* [Condense] Show indicator message when context is condensing (#3765)

* [Condense] Show indicator message when context is condensing

* changeset

* translations

* Another grey screen fix. (#3644)

Memory memory memory

* Fix: Missing or inconsistent syntax highlighting across UI components (#3656)

* fix: Missing or inconsistent syntax highlighting across UI components

- Change file listings to use 'shellsession' for terminal-like highlighting
- Use 'markdown' for code definitions and instructions
- Add file extension-based language detection for new files
- Ensure consistent 'diff' highlighting for all diff content
- Use 'xml' language for error messages
- Make language property required in CodeAccordian
- Set default fallback to 'txt' instead of undefined

Fixes: #3655


* chore: make language property required in CodeBlock

- Updated CodeBlockProps interface to make language property required
- Updated mock implementation to match the interface change
- Ensured CodeAccordian always provides a fallback language value



---------




* Add contact section to pull request template for communication (#3771)

* Update contributors list (#3620)



* More VSCode command / build fixes (#3780)

* Merge remote-tracking branch 'upstream/main' into feat-merge-roocode-v4

---------

## Context

<!-- Brief description of WHAT you’re doing and WHY. -->

## Implementation

<!--

Some description of HOW you achieved it. Perhaps give a high level description of the program flow. Did you need to refactor something? What tradeoffs did you take? Are there things in here which you’d particularly like people to pay close attention to?

-->

## Screenshots

| before | after |
| ------ | ----- |
|        |       |

## How to Test

<!--

A straightforward scenario of how to test your changes will help reviewers that are not familiar with the part of the code that you are changing but want to see it in action. This section can include a description or step-by-step instructions of how to get to the state of v2 that your change affects.

A "How To Test" section can look something like this:

- Sign in with a user with tracks
- Activate `show_awesome_cat_gifs` feature (add `?feature.show_awesome_cat_gifs=1` to your URL)
- You should see a GIF with cats dancing

-->

## Get in Touch

<!-- We'd love to have a way to chat with you about your changes if necessary. If you're in the [Roo Code Discord](https://discord.gg/roocode), please share your handle here. -->
